### PR TITLE
Med tracking reminders

### DIFF
--- a/BridgeApp/BridgeApp.xcodeproj/project.pbxproj
+++ b/BridgeApp/BridgeApp.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0356943720EECD25006A555A /* MedicationReminderDetails.json in Resources */ = {isa = PBXBuildFile; fileRef = 0356943520EECD25006A555A /* MedicationReminderDetails.json */; };
+		0356943820EECD25006A555A /* MedicationReminder.json in Resources */ = {isa = PBXBuildFile; fileRef = 0356943620EECD25006A555A /* MedicationReminder.json */; };
+		0356943A20EECD4D006A555A /* SBAMedicationRemindersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0356943920EECD4D006A555A /* SBAMedicationRemindersViewController.swift */; };
 		F80F175F2033980300352C3E /* SBBSurveyRule+RSDSurveyRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80F175E2033980300352C3E /* SBBSurveyRule+RSDSurveyRule.swift */; };
 		F80F17742033B20C00352C3E /* SurveyNavigationRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80F17732033B20C00352C3E /* SurveyNavigationRuleTests.swift */; };
 		F80F17A32033CB1B00352C3E /* SBBSurvey+RSDTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80F17A22033CB1B00352C3E /* SBBSurvey+RSDTask.swift */; };
@@ -247,6 +250,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0356943520EECD25006A555A /* MedicationReminderDetails.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MedicationReminderDetails.json; sourceTree = "<group>"; };
+		0356943620EECD25006A555A /* MedicationReminder.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MedicationReminder.json; sourceTree = "<group>"; };
+		0356943920EECD4D006A555A /* SBAMedicationRemindersViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAMedicationRemindersViewController.swift; sourceTree = "<group>"; };
 		F80F175E2033980300352C3E /* SBBSurveyRule+RSDSurveyRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SBBSurveyRule+RSDSurveyRule.swift"; sourceTree = "<group>"; };
 		F80F17732033B20C00352C3E /* SurveyNavigationRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyNavigationRuleTests.swift; sourceTree = "<group>"; };
 		F80F17A22033CB1B00352C3E /* SBBSurvey+RSDTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SBBSurvey+RSDTask.swift"; sourceTree = "<group>"; };
@@ -365,6 +371,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0356943420EECCED006A555A /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				0356943620EECD25006A555A /* MedicationReminder.json */,
+				0356943520EECD25006A555A /* MedicationReminderDetails.json */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
 		F825BA5B207FD49D00D29F60 /* Data Tracking */ = {
 			isa = PBXGroup;
 			children = (
@@ -450,6 +465,7 @@
 		F83B44A72032467D002825AE /* BridgeApp */ = {
 			isa = PBXGroup;
 			children = (
+				0356943420EECCED006A555A /* Resources */,
 				F83B44A82032467D002825AE /* BridgeApp.h */,
 				F818E2402032B07D00C538ED /* README.md */,
 				F83B44A92032467D002825AE /* Info-iOS.plist */,
@@ -632,6 +648,7 @@
 		F8A5CE3520A2ADFF00E9FD75 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				0356943920EECD4D006A555A /* SBAMedicationRemindersViewController.swift */,
 				F8A5CE4B20A2B5C400E9FD75 /* SBAAppDelegate.swift */,
 				F8A5CE4920A2AE7100E9FD75 /* SBARootViewController.swift */,
 				F8A5CE4D20A2BBEF00E9FD75 /* CatastrophicError.storyboard */,
@@ -916,11 +933,13 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0356943820EECD25006A555A /* MedicationReminder.json in Resources */,
 				F8A5CE4F20A2BBEF00E9FD75 /* CatastrophicError.storyboard in Resources */,
 				F8C7D4132092A1F5007490BC /* SBASymptomLoggingCell.xib in Resources */,
 				F85AABE920800D120059F019 /* SBATrackedLoggingCell.xib in Resources */,
 				F818E2412032B07E00C538ED /* README.md in Resources */,
 				F886FD342036067300EF2248 /* BridgeApp.strings in Resources */,
+				0356943720EECD25006A555A /* MedicationReminderDetails.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -969,6 +988,7 @@
 				F8A5CE4C20A2B5C400E9FD75 /* SBAAppDelegate.swift in Sources */,
 				F8479523207FEA9D0024A230 /* SBATrackedItemsStepNavigator.swift in Sources */,
 				F886FD2D2035244F00EF2248 /* NSPredicate+Utilities.swift in Sources */,
+				0356943A20EECD4D006A555A /* SBAMedicationRemindersViewController.swift in Sources */,
 				F84794F8207FDEED0024A230 /* SBAFactory.swift in Sources */,
 				F8479525207FEA9D0024A230 /* SBATrackedSelectionDataSource.swift in Sources */,
 				F89B3DEC20C7155D002EAE2D /* SBAMedicationLoggingStepObject.swift in Sources */,

--- a/BridgeApp/BridgeApp/Resources/MedicationReminder.json
+++ b/BridgeApp/BridgeApp/Resources/MedicationReminder.json
@@ -1,0 +1,29 @@
+{
+    "identifier":"medicationReminder",
+    "shouldHideActions":["skip"],
+    "progressMarkers":[],
+    "steps":[
+             {
+             "identifier": "medicationReminder",
+             "type": "form",
+             "title": "Let's set a Reminder for your Medications",
+             "detail":"When do you want us to remind you to take your Parkinson's medications? You can always change them later.",
+             "image":{
+                "type": "fetchable",
+                "imageName":"remindersIcon",
+                "placementType":"iconBefore"
+             },
+                "colorTheme": {
+                "usesLightStyle": false
+             },
+             "uiHint": "list",
+             "dataType": "multipleChoice.integer",
+             "choices": [
+                         {
+                         "text": "15 minutes before medication time",
+                         "value": 15
+                         }
+                         ]
+             }
+        ]
+}

--- a/BridgeApp/BridgeApp/Resources/MedicationReminderDetails.json
+++ b/BridgeApp/BridgeApp/Resources/MedicationReminderDetails.json
@@ -1,0 +1,32 @@
+{
+    "identifier":"medicationReminderDetails",
+    "shouldHideActions":["skip"],
+    "progressMarkers":[],
+    "steps":[
+             {
+             "identifier": "medicationReminderDetails",
+             "type": "form",
+             "title": "How many minutes before medication time would you like to be notified?",
+             "uiHint": "list",
+             "dataType": "multipleChoice.integer",
+             "choices": [
+                         {
+                         "text": "15 minutes before",
+                         "value": 15
+                         },
+                         {
+                         "text": "30 minutes before",
+                         "value": 30
+                         },
+                         {
+                         "text": "45 minutes before",
+                         "value": 45
+                         },
+                         {
+                         "text": "60 minutes before",
+                         "value": 60
+                         }
+                         ]
+             }
+        ]
+}

--- a/BridgeApp/BridgeApp/iOS/SBAMedicationRemindersViewController.swift
+++ b/BridgeApp/BridgeApp/iOS/SBAMedicationRemindersViewController.swift
@@ -1,0 +1,152 @@
+//
+//  SBAMedicationRemindersViewController.swift
+//  mPower2
+//
+//  Copyright © 2018 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+import BridgeApp
+
+class SBAMedicationRemindersViewController: RSDTableStepViewController {
+    
+    func showReminderDetailsTask() {
+        do {
+            // Instantiate and create the reminder details task
+            let resourceTransformer = RSDResourceTransformerObject(resourceName: "MedicationReminderDetails")
+            let task = try RSDFactory.shared.decodeTask(with: resourceTransformer)
+            let taskPath = RSDTaskPath(task: task)
+            
+            // See if we currently have any reminder intervals saved and, if so, add them to the result
+            // for our new task so they are prepopulated for the user
+            if let intervals = intervals(from: taskController.taskPath),
+                intervals.count > 0,
+                let stepNavigator = task.stepNavigator as? RSDConditionalStepNavigator,
+                let firstStep = stepNavigator.steps.first {
+                
+                update(taskPath: taskPath, with: intervals, for: firstStep.identifier)
+            }
+            
+            let vc = RSDTaskViewController(taskPath: taskPath)
+            vc.delegate = self
+            present(vc, animated: true, completion: nil)
+            
+        } catch let err {
+            fatalError("Failed to decode the task. \(err)")
+        }
+    }
+
+    override func setupModel() {
+        
+        super.setupModel()
+        
+        // We want a section label above the first choice cell, which doesn't have one by default.
+        // So we set the title of that table item
+        (tableData?.sections.first)?.title = "Add reminders"
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        // Override default behavior to show the details task so the user can select their intervals
+        showReminderDetailsTask()
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+
+        // Get the cell from super and update the label with the cancatenation of our current reminder intervals
+        let cell = super.tableView(tableView, cellForRowAt: indexPath)
+        let labelString: String = {
+            if let intervals = intervals(from: taskController.taskPath), intervals.count > 0 {
+                return intervals.compactMap { return String($0) }.joined(separator: ", ") + " minutes before medication time."
+            }
+            else {
+                return "(no reminders set)"
+            }
+        }()
+        cell.textLabel?.text = labelString
+        
+        // Also add a disclosure indicator
+        cell.accessoryType = .disclosureIndicator
+        return cell
+    }
+    
+    func intervals(from taskPath: RSDTaskPath) -> [Int]? {
+        
+        guard taskPath.result.stepHistory.count > 0,
+            let collectionResult = taskPath.result.stepHistory.first as? RSDCollectionResultObject else {
+                return nil
+        }
+
+        var intervalsSelected = [Int]()
+        for intervalResult in collectionResult.inputResults {
+            if let intervalAnswerResult = intervalResult as? RSDAnswerResultObject,
+                let intervalValueArray = intervalAnswerResult.value as? [Int] {
+                for intervalInt in intervalValueArray {
+                    intervalsSelected.append(intervalInt)
+                }
+            }
+        }
+        return intervalsSelected
+    }
+    
+    func update(taskPath: RSDTaskPath, with intervals: [Int], for stepIdentifier: String) {
+        
+        var previousResult = RSDCollectionResultObject(identifier: stepIdentifier)
+        var answerResult = RSDAnswerResultObject(identifier: stepIdentifier,
+                                                 answerType: RSDAnswerResultType(baseType: .integer,
+                                                                                 sequenceType: .array,
+                                                                                 formDataType: .collection(.multipleChoice, .integer),
+                                                                                 dateFormat: nil,
+                                                                                 unit: nil,
+                                                                                 sequenceSeparator: nil))
+        answerResult.value = intervals
+        previousResult.inputResults = [answerResult]
+        taskPath.appendStepHistory(with: previousResult)
+    }
+}
+
+extension SBAMedicationRemindersViewController: RSDTaskViewControllerDelegate {
+    func taskController(_ taskController: RSDTaskController, didFinishWith reason: RSDTaskFinishReason, error: Error?) {
+        dismiss(animated: true, completion: nil)
+    }
+    
+    func taskController(_ taskController: RSDTaskController, readyToSave taskPath: RSDTaskPath) {
+        if let intervals = intervals(from: taskPath),
+            let stepNavigator = self.taskController.taskPath.task?.stepNavigator as? RSDConditionalStepNavigator,
+            let firstStep = stepNavigator.steps.first {
+            
+            // Update our current task results with the intervals selected by the user
+            update(taskPath: self.taskController.taskPath, with: intervals, for: firstStep.identifier)
+            tableView.reloadData()
+        }
+    }
+
+    func taskController(_ taskController: RSDTaskController, asyncActionControllerFor configuration: RSDAsyncActionConfiguration) -> RSDAsyncActionController? {
+        return nil
+    }
+}


### PR DESCRIPTION
Add 'SBAMedicationRemindersViewController' custom step VC to allow user to add multiple medication reminder intervals; Add .json config files for this step and the 'medicationReminderDetails' step (which does not require a custom step VC) to let the user select which reminder intervals they'd like to use.

To use:
let resourceTransformer = RSDResourceTransformerObject(resourceName: "MedicationReminder")
let task = try RSDFactory.shared.decodeTask(with: resourceTransformer)
let vc = RSDTaskViewController(task: task)
vc.delegate = self
present(vc, animated: true, completion: nil)

Then in RSDTaskViewControllerDelegate viewControllerFor:step method:
if let taskVC = taskViewController as? RSDTaskViewController,
taskVC.taskPath.identifier == "medicationReminder" {
return SBAMedicationRemindersViewController(step: step as! RSDStep)
}